### PR TITLE
Upgrade to trumpet@1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "David Manning",
   "license": "MIT",
   "dependencies": {
-    "trumpet": "~1.6.3",
+    "trumpet": "~1.7.1",
     "through": "~2.3.4",
     "duplexer": "~0.1.1"
   },


### PR DESCRIPTION
Newer version of trumpet will fix test failures that occur on 1.6.6 and also help beefy with live reloading issue chrisdickinson/beefy#75. Fix in trumpet: substack/node-trumpet#57.