### PR TITLE
Insert script at the end if HTML has no body tag

### DIFF
--- a/lib/script-injector.js
+++ b/lib/script-injector.js
@@ -34,14 +34,30 @@ function scriptInjector (script) {
       function () {
         if (needToAddScript) {
           this.push(script);
+          needToAddScript = false;
         }
         this.push(null);
       }))
     .pipe(bodyTag);
 
-  tr1.pipe(tr2);
+  // If there were no <body>'s even, append the script at the end of the file
+  var tr3 = through(
+    function (data, enc, cb) {
+      this.push(data);
+      cb();
+    },
+    function () {
+      if (needToAddScript) {
+        this.push(script);
+        needToAddScript = false;
+      }
+      this.push(null);
+    }
+  );
 
-  return duplexer(tr1, tr2);
+  tr1.pipe(tr2).pipe(tr3);
+
+  return duplexer(tr1, tr3);
 }
 
 module.exports = scriptInjector;

--- a/test/dat/test4-output.html
+++ b/test/dat/test4-output.html
@@ -1,0 +1,7 @@
+<h1>Hello World</h1>
+<p>This file is a result of X-to-HTML conversion, or not.</p>
+<script type="text/javascript">
+;(function someCode() {
+  console.log("I'm some code to be inserted inline");
+})()
+</script>

--- a/test/dat/test4.html
+++ b/test/dat/test4.html
@@ -1,0 +1,2 @@
+<h1>Hello World</h1>
+<p>This file is a result of X-to-HTML conversion, or not.</p>

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ var testRunner = function (filename, t) {
 test('inject code before the closing body tag', testRunner.bind(null, 'test1'));
 test('inject code before the first script tag in the header', testRunner.bind(null, 'test2'));
 test('inject code before the first script tag in the body', testRunner.bind(null, 'test3'));
+test('inject code when there is no body tag', testRunner.bind(null, 'test4'));
 
 function someCode () {
   console.log("I'm some code to be inserted inline");


### PR DESCRIPTION
This patch adds script at the end of the file as a last resort if the input HTML is so invalid that it does not even have a `<body>` tag.

Such HTML often comes up from X-to-HTML conversion tools such as marked or GNU source-highlight.

For example, here is what marked generates for the `README.md` file in this repository:

``` html
<h1 id="script-injector">script-injector</h1>
<ol>
<li>provides a through stream that allows you to inject inline javascript into an html text stream.</li>
<li>Uses <a href="https://github.com/substack/node-trumpet"><code>trumpet</code></a> to parse your html.</li>
<li>Should only be used for good, never for evil</li>
</ol>
<h2 id="installation">Installation</h2>
<p><code>npm install script-injector</code></p>
<h2 id="how-to-use">How to use</h2>
<p>Just pipe a stream of html through script-injector. You can pass in either some stringified code or a function object. What could be easier?</p>
<pre><code class="lang-javascript">scriptInjector = require(&#39;script-injector&#39;);

// Then do something like this somewhere else

fs.createReadStream(&#39;anHTMLFile&#39;)
  .pipe(scriptInjector(aFunction))
  .pipe(someOtherPlace);
</code></pre>
<p><code>script-injector</code> will insert the provided code <em>before</em> your first script tags, or just before <code>&lt;/body&gt;</code> if you don&#39;t have any other scripts.</p>
```
